### PR TITLE
Exported the logger outside of closure-compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@
 'use strict';
 
 module.exports = {
+  logger: require('./logger.js'),
   compile: require('./compile.js'),
   gulp: require('./lib/gulp'),
   webpack: require('./lib/webpack'),


### PR DESCRIPTION
When I use compile.js outside of closure-compiler project, I need to be able to display warnings and errors.
So to avoid writing the logger logic each time a project needs to use compiler.js, I exposed it.