### PR TITLE
command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ const out = compile(flags);
 console.info(out.compiledCode);  // will print 'var x = 3;\n'
 ```
 
+Or to install the command-line version, do:
+
+```bash
+npm install -g google-closure-compiler-js
+```
+
+You should now be able to run `google-closure-compiler-js` as a command.
+The `google-closure-compiler-js` command can read from stdin or from a file.
+For example:
+
+```bash
+google-closure-compiler-js code.js > minified.js
+```
+
+Run `google-closure-compiler-js --help` for full usage information.
+
 ## Build Systems
 
 ### Webpack

--- a/cmd.js
+++ b/cmd.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Command-line interface for Google Closure Compiler in JS
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const compile = require('./compile.js');
+const concat = require('concat-stream');
+const minimist = require('minimist');
+const argv = minimist(process.argv.slice(2), {
+  alias: { h: 'help', v: 'version' }
+});
+if (argv.help || argv._[0] === 'help') {
+  const helpfile = path.join(__dirname, 'usage.txt');
+  return fs.readFile(helpfile, 'utf8', function (err, src) {
+    if (err) error(err);
+    else console.log(src);
+  });
+}
+if (argv.version) {
+  return console.log(require('./package.json').version);
+}
+
+var sources = [];
+var infiles = argv._;
+delete argv._;
+if (infiles.length === 0) infiles = ['-'];
+var pending = infiles.length;
+infiles.forEach(function (file) {
+  readInput(file, function (err, src) {
+    if (err) return error(err);
+    sources.push(src);
+    if (--pending === 0) ready();
+  });
+});
+
+function readInput (file, cb) {
+  if (file === '-') {
+    process.stdin.pipe(concat({ encoding: 'string' }, function (body) {
+      cb(null, body);
+    }));
+  } else fs.readFile(file, 'utf8', cb);
+}
+
+function ready () {
+  const flags = Object.assign({
+    jsCode: sources.map(function (src) { return { src: src } })
+  }, argv);
+  const out = compile(flags);
+  console.log(out.compiledCode);
+}
+
+function error (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "20161201.0.0",
   "description": "Check, compile, transpile, optimize and compress JavaScript with Closure Compiler in JS",
   "main": "index.js",
+  "bin": {
+    "google-closure-compiler-js": "cmd.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/google/closure-compiler-js.git"
@@ -24,7 +27,9 @@
     "ncp": "^2.0.0"
   },
   "dependencies": {
+    "concat-stream": "^1.5.2",
     "gulp-util": "^3.0.7",
+    "minimist": "^1.2.0",
     "webpack-core": "^0.6.8"
   }
 }

--- a/usage.txt
+++ b/usage.txt
@@ -1,0 +1,110 @@
+usage: google-closure-compiler-js {OPTIONS} [FILES]
+
+Compile FILES with google-closure-compiler-js.
+
+If FILES is not given, read from stdin ("-").
+
+OPTIONS are:
+
+-h --help
+
+  Show this message.
+
+-v --version
+
+  Print the version number.
+
+--angularPass (default: false)
+
+  Generate $inject properties for AngularJS for functions annotated with
+  @ngInject
+
+--applyInputSourceMaps (default: true)
+
+  Compose input source maps into output source map
+
+--assumeFunctionWrapper (default: false)
+
+  Enable additional optimizations based on the assumption that the output will
+  be wrapped with a function wrapper. This flag is used to indicate that
+  "global" declarations will not actually be global but instead isolated to the
+  compilation unit. This enables additional optimizations.
+
+--checksOnly (default: false)
+
+  Don't generate output. Run checks, but no optimization passes.
+
+--compilationLevel (default: SIMPLE)
+
+  Specifies the compilation level to use.
+  Options: WHITESPACE_ONLY, SIMPLE, ADVANCED
+
+--dartPass (default: false)
+--defines (default: null)
+
+  Overrides the value of variables annotated with `@define`, an object mapping
+  names to primitive types.
+
+--env (default: BROWSER)
+
+  Determines the set of builtin externs to load.
+  Options: BROWSER, CUSTOM
+
+--exportLocalPropertyDefinitions (default: false)
+--generateExports (default: false)
+
+  Generates export code for those marked with @export.
+
+--languageIn (default: ES6)
+
+  Sets what language spec that input sources conform to.
+
+--languageOut (default: ES5)
+
+  Sets what language spec the output should conform to.
+
+--newTypeInf (default: false)
+
+  Checks for type errors using the new type inference algorithm.
+
+--outputWrapper (default: null)
+
+  Interpolate output into this string, replacing the token `%output%`
+
+--polymerPass (default: false)
+
+  Rewrite Polymer classes to be compiler-friendly.
+
+--preserveTypeAnnotations (default: false)
+
+--processCommonJsModules (default: false)
+
+  Process CommonJS modules to a concatenable form, i.e., support `require`
+  statements.
+
+--renamePrefixNamespace
+
+  Specifies the name of an object that will be used to store all non-extern globals.
+
+--rewritePolyfills (default: false)
+
+  Rewrite ES6 library calls to use polyfills provided by the compiler's runtime.
+
+--useTypesForOptimization (default: false)
+
+  Enable or disable the optimizations based on available type information.
+  Inaccurate type annotations may result in incorrect results.
+
+--warningLevel (default: DEFAULT)
+
+  Specifies the warning level to use.
+  Options: QUIET, DEFAULT, VERBOSE
+
+--externs
+
+  Additional externs to use for this compile.
+
+--createSourceMap (default: false)
+
+  Generates a source map mapping the generated source file back to its original
+  sources.


### PR DESCRIPTION
This pull request adds a command-line interface including usage information and instructions to install the command-line program from npm. With this patch the interface is now:

```bash
$ google-closure-compiler-js file1.js file2.js > minified.js
```

Or the program can also read from stdin, similar to other minifiers like uglifyjs:

```bash
$ browserify main.js | google-closure-compiler-js > minified.js
```

I have signed the contributor license agreement.