### PR TITLE
Properly pass stdin to compiler from CLI

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -66,7 +66,7 @@ function readFile(path, cb) {
     let src = '';
     process.stdin.resume();
     process.stdin.on('data', buf => src += buf.toString());
-    process.stdin.on('end', () => cb(src));
+    process.stdin.on('end', () => cb({src, path: '-'}));
   } else {
     fs.readFile(path, 'utf8', (err, src) => err ? error(err) : cb({src, path}));
   }


### PR DESCRIPTION
`sources` is expected to consist of objects, whereas the current implementation pushes a string. Right now this results in a blank output from piping input to the CLI. This PR fixes that behavior and allows usage like:


```
$ google-closure-compiler-js < entry.js > min.js
```
```
$ browserify entry.js | google-closure-compiler-js > min.js
```