### PR TITLE
Fix reading from stdin

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -66,7 +66,7 @@ function readFile(path, cb) {
     let src = '';
     process.stdin.resume();
     process.stdin.on('data', buf => src += buf.toString());
-    process.stdin.on('end', () => cb(src));
+    process.stdin.on('end', () => cb({src}));
   } else {
     fs.readFile(path, 'utf8', (err, src) => err ? error(err) : cb({src, path}));
   }


### PR DESCRIPTION
`compile` takes a list of sources in format `{ src: "js" }`. When read from `stdin` its content doesn't wrap into object and `compile` returns an empty output.