### PR TITLE
Use webpack plugin API instead of console to report errors and warnings

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -20,9 +20,18 @@
 
 'use strict';
 
+function formatMessage(msg) {
+  let formatted = `(${msg.type}) ${msg.description}`;
+
+  if (msg.file && msg.lineNo >= 0) {
+    formatted = `${msg.file}:${msg.lineNo} ${formatted}`;
+  }
+
+  return formatted;
+}
+
 module.exports = function(args) {
   const compile = require('../compile');
-  const logger = require('../logger');
   const RawSource = require('webpack-core/lib/RawSource');
   const SourceMapSource = require('webpack-core/lib/SourceMapSource');
 
@@ -50,10 +59,17 @@ module.exports = function(args) {
             options.jsCode = [file];
 
             const output = compile(options);
-            if (logger(options, output)) {
-              const message = `Compilation error, ${output.errors.length} errors`;
-              compilation.errors.push(new Error(message));
-              return;  // don't save compilation
+
+            output.errors.forEach(msg => {
+              compilation.errors.push(new Error(formatMessage(msg)));
+            });
+
+            output.warnings.forEach(msg => {
+              compilation.warnings.push(new Error(formatMessage(msg)));
+            });
+
+            if (output.errors.length > 0) {
+              return; // don't save compilation
             }
 
             let result;
@@ -64,7 +80,6 @@ module.exports = function(args) {
               result = new RawSource(output.compiledCode);
             }
             compilation.assets[name] = result;
-
           });
         });
 


### PR DESCRIPTION
The closure-compiler-js webpack plugin is currently using the globally defined logger for error reporting, which ultimately dumps all errors to stdout.

This is not how errors should be handled in webpack. Admittedly, the webpack docs don't give too much information, but it seems to be common practice to push errors into the compilation.errors
array, so that webpack can later handle (e.g. format) all errors equally.

At the moment, it is difficult to capture closure-compiler-js errors in webpack builds. Build environments that follow the usual convention will not capture the error details at all.

A possible workaround is to override the global logger property, but IMO that is a rather dirty hack, and since the compilation object is not exposed to the logger function, the new handler could possibly suppress the stdout logging, but not redirect the errors properly.

See here for a discussion: https://stackoverflow.com/questions/42364742/webpack-plugin-error-management