### PR TITLE
Promote installing as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This is an experimental release - meaning some features are not available and pe
 First, install the latest version:
 
 ```bash
-yarn add google-closure-compiler-js  # or
-npm install --save google-closure-compiler-js
+yarn add google-closure-compiler-js --dev  # or
+npm install --save-dev google-closure-compiler-js
 ```
 
 The module supports modern web browsers as well as Node v4 LTS, and provides `compile` as a low-level method to compile JavaScript.


### PR DESCRIPTION
Most of the time people will use this package as part of their build
process. Except in rare cases, it doesn't make sense to install this
package as a regular dependency.