### PR TITLE
Add createSourceMap CLI argument for cmd.js

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -112,6 +112,11 @@ function ready(sources, externs) {
   }
   console.log(output.compiledCode);
 
+  if (flags.createSourceMap) {
+    const sourceMapBase64 = new Buffer(output.sourceMap).toString('base64');
+    console.log('//# sourceMappingURL=data:application/json;charset=utf-8;base64,' + sourceMapBase64);
+  }
+
   process.exit(code);
 }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -30,7 +30,21 @@ suite('closure', () => {
       warningLevel: 'VERBOSE',
     };
     const out = compile(flags);
-    assertCompileOk(out, 'var x=3;')
+
+    assertCompileOk(out, 'var x=3;');
+    assert.equal(out.sourceMap, null);
+  });
+
+  test('simple with source map', () => {
+    const flags = {
+      jsCode: [{src: 'const x = 1 + 2;'}],
+      warningLevel: 'VERBOSE',
+      createSourceMap: true,
+    };
+    const out = compile(flags);
+
+    assertCompileOk(out, 'var x=3;');
+    assert.equal(out.sourceMap, `{\n"version":3,\n"file":"",\n"lineCount":1,\n"mappings":"AAAA,IAAMA,EAAI;",\n"sources":["Input_0"],\n"names":["x"]\n}\n`);
   });
 
   test('advanced', () => {


### PR DESCRIPTION
This PR adds `createSourceMap` CLI argument that inlines source maps into the output. The `createSourceMap` option right now causes the compiler to produce source maps but these are ignored.

I also added a test to check that the source map is really generated only when needed. However, the `cmd.js` script itself isn't tested.

Solves #84