### PR TITLE
 Make sure build_compiler.js points to the closure-compiler GWT pom 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ repository.
 
 [1]: https://github.com/google/closure-compiler/tree/master/src/com/google/javascript/jscomp/gwt/super
 
+For building it, first init and update the `closure-compiler` git submodule:
+
+```bash
+git submodule init closure-compiler
+git submodule update
+```
+
+Then and add the `allow-snapshots` section to `~/.m2/settings.xml` like in [here](https://github.com/google/closure-compiler#building-it-yourself).
+
+After that you can finally build the GWT port:
+
+```bash
+./build_compiler.js
+```
+
 ## Version History
 
 Closure Compiler release notes can be found on the

--- a/build_compiler.js
+++ b/build_compiler.js
@@ -26,7 +26,7 @@ const ncp = require('ncp');
 
 const moduleName = 'com.google.javascript:closure-compiler-gwt';
 const compilerBuild = spawn(
-    'mvn', ['-DskipTests', '--projects', moduleName, 'clean', 'install'], {
+    'mvn', ['-f', 'pom-gwt.xml', '-DskipTests', '--projects', moduleName, 'clean', 'install'], {
       cwd: './closure-compiler',
       stdio: 'inherit',
     });


### PR DESCRIPTION
I found out that without this change it is not currently possible to build because the module
has be commented out from the main pom.

I also added some instructions in the README for building.