### PR TITLE
fixed issue #65 'Not compatible with node.js v4' (tested on 4.8.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
- - stable
+ - lts/argon

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 
 node_js:
  - lts/argon
+ - stable
+ 

--- a/cmd.js
+++ b/cmd.js
@@ -55,7 +55,7 @@ delete argv.jsCode;
 const externs = readAllFiles(toArray(argv.externs));
 delete argv.externs;
 
-Promise.all([sources, externs]).then(arr => ready(...arr)).catch(error);
+Promise.all([sources, externs]).then(arr => ready(arr[0], arr[1])).catch(error);
 
 /**
  * Minimist gives us a string, array or null: normalize to array.
@@ -110,7 +110,12 @@ function parseDefines(flags){
   if (Array.isArray(flags.defines) || typeof flags.defines === "string"){
     let defines = {};
     function parseDefines(d) {
-      let [key, value] = d.split("=");
+      let key, value;
+      {
+        let a = d.split("=");
+        key = a[0];
+        value = a[1];
+      }
       defines[key] =
        /^(?:true|false)$/.test(value)
         ? value === 'true' 


### PR DESCRIPTION
Had the same issue as https://github.com/google/closure-compiler-js/issues/65 - the only incompatibilities appear to be in cmd.js.